### PR TITLE
Exclude SRPM if they happen to be in the test repository

### DIFF
--- a/mtps-run-tests
+++ b/mtps-run-tests
@@ -141,6 +141,10 @@ nevras_in_repo="$(
         sed -n -e "/^${REPONAME}[[:space:]]/ s/^${REPONAME}[[:space:]]//p"
 )"
 
+# Exclude SRPMs if they happen to be in the repository;
+# SRPM cannot be dnf-installed anyway
+nevras_in_repo="$(echo "$nevras_in_repo" | sed -n -e "/\.src$/d;p")"
+
 if [ -n "$SKIPLANGPACK" ]; then
     echo "Skipping https://fedoraproject.org/wiki/Packaging:Langpacks packages."
     nevras_in_repo="$(echo "$nevras_in_repo" | sed -n -e "/-langpack-/d;p")"


### PR DESCRIPTION
SRPM packages cannot be dnf-installed and the test
would later fail on them.

Note: if the repository is prepared by mini-tps, then there
should be no SRPMs inside. However, the repository can be prepared
by CI systems and SRPMs may appear there.

Signed-off-by: Michal Srb <michal@redhat.com>