### PR TITLE
Fix --onlyinrepo option in mtps-get-task

### DIFF
--- a/mini-tps.spec
+++ b/mini-tps.spec
@@ -1,6 +1,6 @@
 Name: mini-tps
 Version: 0.1
-Release: 148%{?dist}
+Release: 149%{?dist}
 Summary: Mini TPS - Test Package Sanity
 
 License: GPLv2
@@ -42,6 +42,9 @@ cp -rfp optrepos/*.repo %{buildroot}%{_datarootdir}/mini-tps/optrepos
 %{_datarootdir}/mini-tps/*
 
 %changelog
+* Tue Sep 06 2022 Michal Srb <michal@redhat.com> - 0.1-149
+- Fix --onlyinrepo option in mtps-get-task.
+
 * Wed Oct 13 2021 Michal Srb <michal@redhat.com> - 0.1-145
 - Build with the latest changes.
 

--- a/mtps-get-task
+++ b/mtps-get-task
@@ -666,9 +666,7 @@ for task in $TASKS; do
     query_task_files="$(mk_query_task_result $task)" # Holds plain XML
     answer_task_result="$(send_query "$query_task_files")"
     rpms_from_task="$(rpms_from_answer "$ARCH" "$answer_task_result")"
-    rpms_from_task_all+=" $rpms_from_task"
     rpms_from_task_noarch="$(rpms_from_answer "noarch" "$answer_task_result")"
-    rpms_from_task_noarch_all+=" $rpms_from_task_noarch"
     srpm="$(srpms_from_answer "$answer_task_result")"
     if [ -n "$srpm" ]; then
         srpm_pkg_file="$(basename $srpm)"
@@ -694,6 +692,8 @@ for task in $TASKS; do
         rpms_from_task="$(filter_available "$ARCH" "$rpms_from_task")"
         rpms_from_task_noarch="$(filter_available "noarch" "$rpms_from_task_noarch")"
     fi
+    rpms_from_task_all+=" $rpms_from_task"
+    rpms_from_task_noarch_all+=" $rpms_from_task_noarch"
 done
 
 echo "NVR: $nvr"


### PR DESCRIPTION
The --onlyinrepo option wasn't working as expected.

The rest of the script expects to find the list of RPMs
in the "rpms_from_task_all" variable (and its "noarch"
counterpart). "rpms_from_task" is not used for anything later
in the script.

Signed-off-by: Michal Srb <michal@redhat.com>