### PR TITLE
OSCI-4333: Do not try removing package which introduced /etc/dnf/protected.d file.

### DIFF
--- a/mtps-pkg-test
+++ b/mtps-pkg-test
@@ -547,6 +547,16 @@ case $TEST in
         msg_prepare "removing" "$NEVRA"
         pkg_update_to_new_if_present "$NEVRA"
         pkg_install_new_if_absent "$NEVRA"
+
+        # OSCI-4333: We have to check again if the pakage can be removed
+        # now after we installed its latest version. It can happen that
+        # the update introduced new /etc/yum/protected.d/* file which makes
+        # it uninstallable.
+        if ! pkg_can_be_removed "$NEVRA"; then
+            echo "Skipping test: $TEST for $NEVRA. Package cannot be clearly removed."
+            exit 0
+        fi
+
         msg_run "remove" "$NEVRA"
         pkg_remove_any "$NEVRA"
         ;;


### PR DESCRIPTION
We have to check again if the pakage can be removed after we installed its latest version. It can happen that the update introduced new /etc/dnf/protected.d/* file which makes it uninstallable.

Signed-off-by: Jan Kaluza <jkaluza@redhat.com>