### PR TITLE
Add "--rpmverify" option

### DIFF
--- a/mini-tps.spec
+++ b/mini-tps.spec
@@ -1,6 +1,6 @@
 Name: mini-tps
 Version: 0.1
-Release: 158%{?dist}
+Release: 159%{?dist}
 Summary: Mini TPS - Test Package Sanity
 
 License: GPLv2
@@ -59,6 +59,9 @@ cp -pf profiles/centos-stream/prepare-system %{buildroot}%{_libexecdir}/mini-tps
 %{_libexecdir}/mini-tps/*
 
 %changelog
+* Wed Jul 26 2023 Michal Srb <michal@redhat.com> - 0.1-159
+- Add option to rpm-verify installed packages (OSCI-1240)
+
 * Wed Mar 29 2023 Michal Srb <michal@redhat.com> - 0.1-158
 - Ignore known scriptlet false positives
 

--- a/mtps-pkg-test
+++ b/mtps-pkg-test
@@ -246,6 +246,43 @@ pkg_is_absent() {
     return $ret
 }
 
+rpm_db_verify() {
+    # Run "rpm --verify" on the installed package
+    local name="$1" && shift
+    debug "${FUNCNAME[0]}: $name"
+    local ret=
+
+    echo
+    echo
+    echo "***"
+    echo "Verifying that the installed files match the metadata in the RPM database..."
+    echo "$ rpm --verify $name"
+    rpm --verify "$name" && ret=0 || ret=1
+    echo
+    if [ "$ret" != "0" ]; then
+        echo "Some discrepancies were found. This is how to interpret the output above:"
+        echo
+        echo "S file Size differs"
+        echo "M Mode differs (includes permissions and file type)"
+        echo "5 digest (formerly MD5 sum) differs"
+        echo "D Device major/minor number mismatch"
+        echo "L readLink(2) path mismatch"
+        echo "U User ownership differs"
+        echo "G Group ownership differs"
+        echo "T mTime differs"
+        echo "P caPabilities differ"
+        echo
+        echo "These findings might be real bugs that can be fixed in the spec file,"
+        echo "or they might be false positives that can be suppressed. See the \"%verify\""
+        echo "scriptlet description in the RPM docs: https://rpm-software-management.github.io/rpm/manual/spec.html"
+    else
+        echo "(ok)"
+    fi
+    echo "***"
+
+    return $ret
+}
+
 get_installed_nevra_new() {
     # Sytem can have a few same packages installed
     # rpm -q "kernel-rt-kvm"
@@ -484,13 +521,14 @@ Options:
 -n, --nevra=NEVRA                            package to test: name-[epoch:]version-release.arch
 -r, --revertchanges                          revert changes made to system
 -x, --scriptletcheck                         check output and fail if problems with scriptlets are found
+-f, --rpmverify                              run "rpm --verify" to verify that what's installed matches the metadata in the RPM database
 -h, --help                                   display this help and exit
 EOF
 }
 
 # http://wiki.bash-hackers.org/howto/getopts_tutorial
 opt_str="$@"
-opt=$(getopt -n "$0" --options "hvs:t:n:r:x" --longoptions "help,verbose,start:,test:,nevra:,revertchanges,scriptletcheck" -- "$@")
+opt=$(getopt -n "$0" --options "hvs:t:n:r:x:f" --longoptions "help,verbose,start:,test:,nevra:,revertchanges,scriptletcheck,rpmverify" -- "$@")
 eval set -- "$opt"
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -501,6 +539,10 @@ while [[ $# -gt 0 ]]; do
         -t|--test)
             TEST="$2"
             shift 2
+            ;;
+        -f|--rpmverify)
+            RPM_VERIFY="yes"
+            shift
             ;;
         -n|--nevra)
             NEVRA="$2"
@@ -548,6 +590,7 @@ START="${START:-}"
 NEVRA="${NEVRA:-}"
 REVERT="${REVERT:-}"
 CHECK_SCRIPTLETS="${CHECK_SCRIPTLETS:-}"
+RPM_VERIFY="${RPM_VERIFY:-}"
 
 DEBUG_OUT="/dev/null"
 if [ -n "$DEBUG" ]; then
@@ -593,6 +636,15 @@ case $TEST in
         else
             pkg_install_new_if_absent "$NEVRA"
         fi
+        ret=$?
+        if [ -n "$RPM_VERIFY" ]; then
+            if [ "$ret" = "0" ]; then
+                # The "install" test succeeded so we can proceed and rpm-verify the results
+                rpm_db_verify "$NEVRA"
+                ret=$?
+            fi
+        fi
+        exit $ret
         ;;
     update)
         msg_prepare "updating" "$NEVRA"
@@ -614,6 +666,15 @@ case $TEST in
         else
             pkg_update_to_new_if_present "$NEVRA"
         fi
+        ret=$?
+        if [ -n "$RPM_VERIFY" ]; then
+            if [ "$ret" = "0" ]; then
+                # The "update" test succeeded so we can proceed and rpm-verify the results
+                rpm_db_verify "$NEVRA"
+                ret=$?
+            fi
+        fi
+        exit $ret
         ;;
     downgrade)
         msg_prepare "downgrading" "$NEVRA"

--- a/mtps-run-tests
+++ b/mtps-run-tests
@@ -36,6 +36,7 @@ Options:
 -x, --scriptletcheck                         check output and fail if problems with scriptlets are found
 -r, --repo=NAME                              YUM repo name, must be present, check with: yum repolist --enabled
 -c, --critical                               tests set are critical, example: update, downgrade
+-f, --rpmverify                              run "rpm --verify" to verify that what's installed matches the metadata in the RPM database
 -h, --help                                   display this help and exit
 -v, --verbose                                print debug messages
 EOF
@@ -57,13 +58,17 @@ box_out() {
 
 # http://wiki.bash-hackers.org/howto/getopts_tutorial
 opt_str="$@"
-opt=$(getopt -n "$0" --options "hvct:r:s:l:x" --longoptions "help,verbose,skiplangpack,scriptletcheck,critical,test:,repo:,selinux:" -- "$@")
+opt=$(getopt -n "$0" --options "hvct:r:s:l:x:f" --longoptions "help,verbose,skiplangpack,scriptletcheck,rpmverify,critical,test:,repo:,selinux:" -- "$@")
 eval set -- "$opt"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -t|--test)
             TEST="$2"
             shift 2
+            ;;
+        -f|--rpmverify)
+            RPM_VERIFY="yes"
+            shift
             ;;
         -r|--repo)
             REPONAME="$2"
@@ -112,6 +117,7 @@ SELINUX="${SELINUX:-}"
 CRITICAL="${CRITICAL:-}"
 SKIPLANGPACK="${SKIPLANGPACK:-}"
 CHECK_SCRIPTLETS="${CHECK_SCRIPTLETS:-}"
+RPM_VERIFY="${RPM_VERIFY:-}"
 # Put logs by default at CDIR/mtps-logs
 LOGS_DIR="${LOGS_DIR:-mtps-logs}"
 
@@ -193,7 +199,7 @@ for nevra in $nevras_in_repo; do
         "  SELINUX:     $(getenforce || echo "unknown")" \
         "  YUM HISTORY: $START"
     logfname="${LOGS_DIR%%/}/$TESTRUN_ID-$TEST-$nevra.log"
-    mtps-pkg-test --test="$TEST" ${CHECK_SCRIPTLETS:+--scriptletcheck} --nevra="$nevra" 2>&1 | tee "$logfname"
+    mtps-pkg-test --test="$TEST" ${CHECK_SCRIPTLETS:+--scriptletcheck} ${RPM_VERIFY:+--rpmverify} --nevra="$nevra" 2>&1 | tee "$logfname"
     test_status="${PIPESTATUS[0]}"
     #box_out \
     #    "REVERT CHANGES" \


### PR DESCRIPTION
"rpm --verify" should ideally report no problems right after installation.
I.e. what was just installed should match what's in the RPM database.

TPS also performs this check and this feature is an attempt to close the gap
between installability and TPS.

See: OSCI-1240

Signed-off-by: Michal Srb <michal@redhat.com>
