### PR TITLE
Add profiles for Fedora

### DIFF
--- a/mini-tps.spec
+++ b/mini-tps.spec
@@ -39,18 +39,22 @@ mkdir -p %{buildroot}%{_libexecdir}/mini-tps/viewer/
 cp -pf viewer/generate-result-json %{buildroot}%{_libexecdir}/mini-tps/viewer/
 
 # profiles
-mkdir -p %{buildroot}%{_datarootdir}/mini-tps/profiles/{rhel,centos-stream}/
+mkdir -p %{buildroot}%{_datarootdir}/mini-tps/profiles/{rhel,centos-stream,fedora}/
 # rhel
 cp -rfp profiles/rhel/{repos,optrepos}/ %{buildroot}%{_datarootdir}/mini-tps/profiles/rhel/
 # centos-stream
 cp -rfp profiles/centos-stream/{repos,optrepos}/ %{buildroot}%{_datarootdir}/mini-tps/profiles/centos-stream/
+# fedora
+cp -rfp profiles/fedora/repos/ %{buildroot}%{_datarootdir}/mini-tps/profiles/fedora/
 
 # prepare scripts
-mkdir -p %{buildroot}%{_libexecdir}/mini-tps/{rhel,centos-stream}/
+mkdir -p %{buildroot}%{_libexecdir}/mini-tps/{rhel,centos-stream,fedora}/
 # rhel
 cp -pf profiles/rhel/prepare-system %{buildroot}%{_libexecdir}/mini-tps/rhel/
 # centos-stream
 cp -pf profiles/centos-stream/prepare-system %{buildroot}%{_libexecdir}/mini-tps/centos-stream/
+# fedora
+cp -pf profiles/fedora/prepare-system %{buildroot}%{_libexecdir}/mini-tps/fedora/
 
 %files
 %{_prefix}/local/bin/mtps*

--- a/mini-tps.spec
+++ b/mini-tps.spec
@@ -1,6 +1,6 @@
 Name: mini-tps
 Version: 0.1
-Release: 159%{?dist}
+Release: 160%{?dist}
 Summary: Mini TPS - Test Package Sanity
 
 License: GPLv2
@@ -63,6 +63,9 @@ cp -pf profiles/fedora/prepare-system %{buildroot}%{_libexecdir}/mini-tps/fedora
 %{_libexecdir}/mini-tps/*
 
 %changelog
+* Fri Jul 28 2023 Michal Srb <michal@redhat.com> - 0.1-160
+- Add profiles for Fedora
+
 * Wed Jul 26 2023 Michal Srb <michal@redhat.com> - 0.1-159
 - Add option to rpm-verify installed packages (OSCI-1240)
 

--- a/profiles/fedora/prepare-system
+++ b/profiles/fedora/prepare-system
@@ -1,0 +1,53 @@
+#!/bin/bash -efu
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2023
+# Author: Michal Srb <michal@redhat.com>
+
+# Prepare system for install, remove, downgrade, update tests
+
+echo "Preparing the system for testing..."
+
+if [ -n "$FIXREPO" ]; then
+    echo "Ignoring \"--fixrepo\" option as it has no effect on Fedora profiles"
+fi
+
+# Add buildroot repo, if needed
+if [ -n "$ENABLE_BUILD_ROOT" ]; then
+    echo "Enabling buildroot repository..."
+    FEDORA_NUMBER=$(echo "${PROFILE}" | awk -F'-' '{ print $2 }')
+
+cat << EOF > "/etc/yum.repos.d/${PROFILE}.repo"
+[${PROFILE}-buildroot]
+name=${PROFILE} Buildroot
+baseurl=https://kojipkgs.fedoraproject.org/repos/f${FEDORA_NUMBER}-build/latest/x86_64/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=True
+EOF
+fi
+
+# Make sure fedora and fedora-updates repos are enabled
+dnf config-manager --set-enabled 'fedora' 'updates'
+# Disable all COPR repositories (mini-tps, ...)
+dnf config-manager --set-disabled 'copr:*'
+
+echo "Recreating the DNF cache..."
+dnf clean all
+dnf makecache
+
+echo "Installing packages required for testing..."
+dnf install -y createrepo_c
+
+echo "Updating the system..."
+dnf update -y

--- a/profiles/fedora/repos/fedora-36.repo
+++ b/profiles/fedora/repos/fedora-36.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.

--- a/profiles/fedora/repos/fedora-37.repo
+++ b/profiles/fedora/repos/fedora-37.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.

--- a/profiles/fedora/repos/fedora-38.repo
+++ b/profiles/fedora/repos/fedora-38.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.

--- a/profiles/fedora/repos/fedora-39.repo
+++ b/profiles/fedora/repos/fedora-39.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.

--- a/profiles/fedora/repos/fedora-40.repo
+++ b/profiles/fedora/repos/fedora-40.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.

--- a/profiles/fedora/repos/fedora-41.repo
+++ b/profiles/fedora/repos/fedora-41.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.

--- a/profiles/fedora/repos/fedora-42.repo
+++ b/profiles/fedora/repos/fedora-42.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.

--- a/profiles/fedora/repos/fedora-43.repo
+++ b/profiles/fedora/repos/fedora-43.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.

--- a/profiles/fedora/repos/fedora-44.repo
+++ b/profiles/fedora/repos/fedora-44.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.

--- a/profiles/fedora/repos/fedora-45.repo
+++ b/profiles/fedora/repos/fedora-45.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.

--- a/profiles/fedora/repos/fedora-46.repo
+++ b/profiles/fedora/repos/fedora-46.repo
@@ -1,0 +1,1 @@
+# Empty — Fedora images have all repos we need already baked-in.


### PR DESCRIPTION
Fedora images already come with all the repo files that we need,
and therefore we don't need to modify or replace them.
However, we still need those empty repo files so that we can
list explicitly supported versions:

$ mtps-prepare-system --list
fedora-36
fedora-37
fedora-38
fedora-39
...

Signed-off-by: Michal Srb <michal@redhat.com>