### PR TITLE
Install which and procps-ng in prepare-system (all profiles)

### DIFF
--- a/profiles/centos-stream/prepare-system
+++ b/profiles/centos-stream/prepare-system
@@ -37,7 +37,7 @@ yum clean all
 yum makecache
 
 echo "Installing packages required for testing..."
-yum install -y createrepo_c
+yum install -y createrepo_c which procps-ng
 
 echo "Updating the system..."
 yum update -y

--- a/profiles/fedora/prepare-system
+++ b/profiles/fedora/prepare-system
@@ -56,7 +56,7 @@ echo "Recreating the DNF cache..."
 "$YUMDNFCMD" makecache
 
 echo "Installing packages required for testing..."
-"$YUMDNFCMD" install -y createrepo_c
+"$YUMDNFCMD" install -y createrepo_c which procps-ng
 
 echo "Updating the system..."
 "$YUMDNFCMD" update -y

--- a/profiles/rhel/prepare-system
+++ b/profiles/rhel/prepare-system
@@ -55,7 +55,7 @@ fi
 # yum config-manager --set-enabled astepano-mini-tps || :
 
 echo "Installing required packages for testing"
-yum install -y createrepo_c
+yum install -y createrepo_c which procps-ng
 
 yum update -y
 yum clean all


### PR DESCRIPTION
The scripts use `which` and `ps`, but do not make sure they are available. In e.g. official Fedora base container images, they are not, so the test pipeline fails when run in a container.