### PR TITLE
Skip update if old package can't be installed

### DIFF
--- a/mtps-pkg-test
+++ b/mtps-pkg-test
@@ -35,6 +35,8 @@
 
 : "${PROG:=${0##*/}}"
 
+EXIT_CODE_SKIP=7
+
 # Source `mtps-setup' from $PATH
 if command -v "mtps-setup" >/dev/null; then source "mtps-setup"; fi
 # If previous fails source `mtps-setup` from this script dir
@@ -594,7 +596,7 @@ fi
 if [[ "$TEST" == "install" || "$TEST" == "remove" ]]; then
     if ! pkg_can_be_removed "$NEVRA"; then
         echo "Skipping test: $TEST for $NEVRA. Package cannot be clearly removed."
-        exit 0
+        exit $EXIT_CODE_SKIP
     fi
 fi
 
@@ -621,7 +623,7 @@ case $TEST in
         old_nevra="$(get_old_nevra "$NEVRA" || true)"
         if [ -z "$old_nevra" ]; then
             echo "Cannot find older package than $NEVRA. Skipping test."
-            exit 0
+            exit $EXIT_CODE_SKIP
         fi
         # If there's a bug preventing the old package from installing
         # the dnf downgrade fails but we can't say whether it's because
@@ -635,7 +637,7 @@ case $TEST in
         fi
         if ! pkg_install_if_absent "$old_nevra"; then
             echo "Failed to install $old_nevra. Skipping test."
-            exit 0
+            exit $EXIT_CODE_SKIP
         fi
         # At this point pkg is installed, but can be many installonlypkg(foo) packages
         pkg_remove_any_newer "$NEVRA"
@@ -658,13 +660,13 @@ case $TEST in
         old_nevra="$(get_old_nevra "$NEVRA" || true)"
         if [ -z "$old_nevra" ]; then
             echo "Cannot find older package than $NEVRA. Skipping test."
-            exit 0
+            exit $EXIT_CODE_SKIP
         fi
         echo "Older available package is: $old_nevra"
         pkg_update_to_new_if_present "$NEVRA"
         if ! pkg_install_if_absent "$NEVRA"; then
             echo "Failed to install $NEVRA. Skipping test."
-            exit 0
+            exit $EXIT_CODE_SKIP
         fi
         pkg_remove_any_older "$NEVRA" # This is for installonlypkg(foo) packages, like kernel
         msg_run "downgrade" "$NEVRA"
@@ -685,7 +687,7 @@ case $TEST in
         # it uninstallable.
         if ! pkg_can_be_removed "$NEVRA"; then
             echo "Skipping test: $TEST for $NEVRA. Package cannot be clearly removed."
-            exit 0
+            exit $EXIT_CODE_SKIP
         fi
 
         msg_run "remove" "$NEVRA"

--- a/mtps-pkg-test
+++ b/mtps-pkg-test
@@ -209,7 +209,7 @@ pkg_remove_any() {
     return $ret
 }
 
-pkg_install_new_if_absent() {
+pkg_install_if_absent() {
     local nevra="$1" && shift
     local name="$(from_nevra "$nevra" "name")"
     debug "${FUNCNAME[0]}: $name"
@@ -217,12 +217,10 @@ pkg_install_new_if_absent() {
         debug "${FUNCNAME[0]}: package $name is present. Not installing $nevra."
         return 0
     fi
-    local ret=0
-    "$YUMDNFCMD" -y install --allowerasing "$nevra" || ret=1
-    if [ "$ret" -ne 0 ]; then
+    if ! "$YUMDNFCMD" -y install --allowerasing "$nevra"; then
         echo "Installation of $nevra failed."
         echo "See $YUMDNFCMD command output above for more information."
-        exit 1
+        return 1
     fi
     if pkg_is_absent "$name"; then
         echo "Package $name is absent after installation."
@@ -335,7 +333,7 @@ pkg_downgrade_if_present() {
     fi
     # installonlypkg(foo) case
     local installed_nevra_old="$(get_installed_nevra_oldest "$name")"
-    echo "The oldest installed package: $installed_nevra_old"
+    echo "The (oldest) installed package: $installed_nevra_old"
     if nevra_older_then "$installed_nevra_old" "$nevra"; then
         echo "Not downgrading package: $nevra. There is already installed old package: $installed_nevra_old"
         return 0
@@ -410,25 +408,6 @@ pkg_remove_any_older() {
             continue
         fi
     done
-}
-
-pkg_install_old_if_absent() {
-    # Installs package < nevra, if pkg with name is absent.
-    # 2nd column yum output: 12:4.3.6-25.el8+7
-    local nevra="$1" && shift
-    local name="$(from_nevra "$nevra" "name")"
-    if pkg_is_present "$name"; then
-        debug "Package $name is present. Not installing."
-        return 0
-    fi
-    local old_nevra="$(get_old_nevra "$nevra")"
-    echo "Installing older $old_nevra for $nevra"
-    "$YUMDNFCMD" -y install --allowerasing "$old_nevra"
-    if pkg_is_absent "$old_nevra"; then
-        echo "Could not install: $old_nevra."
-        return 1
-    fi
-    return 0
 }
 
 pkg_update_to_new_if_present() {
@@ -625,9 +604,9 @@ case $TEST in
         pkg_remove_any "$NEVRA"
         msg_run "install" "$NEVRA"
         if [ -n "$CHECK_SCRIPTLETS" ]; then
-            run_with_scriptlet_check pkg_install_new_if_absent "$NEVRA"
+            run_with_scriptlet_check pkg_install_if_absent "$NEVRA"
         else
-            pkg_install_new_if_absent "$NEVRA"
+            pkg_install_if_absent "$NEVRA"
         fi
         ret=$?
         if [[ "$ret" -eq 0 && -n "$RPM_VERIFY" ]]; then
@@ -642,13 +621,22 @@ case $TEST in
         old_nevra="$(get_old_nevra "$NEVRA" || true)"
         if [ -z "$old_nevra" ]; then
             echo "Cannot find older package than $NEVRA. Skipping test."
-            # Skipping test
             exit 0
         fi
-        echo "Found available older package: $old_nevra"
-        # At this point an old pkg is available in repo
-        pkg_downgrade_if_present "$NEVRA"
-        pkg_install_old_if_absent "$NEVRA"
+        # If there's a bug preventing the old package from installing
+        # the dnf downgrade fails but we can't say whether it's because
+        # of the new package or the old one.
+        # So rather, remove the package, install old version, and if that fails
+        # skip the test.
+        if pkg_can_be_removed "$NEVRA"; then
+            pkg_remove_any "$NEVRA"
+        else
+            pkg_downgrade_if_present "$NEVRA"
+        fi
+        if ! pkg_install_if_absent "$old_nevra"; then
+            echo "Failed to install $old_nevra. Skipping test."
+            exit 0
+        fi
         # At this point pkg is installed, but can be many installonlypkg(foo) packages
         pkg_remove_any_newer "$NEVRA"
         msg_run "update" "$NEVRA"
@@ -670,12 +658,14 @@ case $TEST in
         old_nevra="$(get_old_nevra "$NEVRA" || true)"
         if [ -z "$old_nevra" ]; then
             echo "Cannot find older package than $NEVRA. Skipping test."
-            # Skipping test
             exit 0
         fi
         echo "Older available package is: $old_nevra"
         pkg_update_to_new_if_present "$NEVRA"
-        pkg_install_new_if_absent "$NEVRA"
+        if ! pkg_install_if_absent "$NEVRA"; then
+            echo "Failed to install $NEVRA. Skipping test."
+            exit 0
+        fi
         pkg_remove_any_older "$NEVRA" # This is for installonlypkg(foo) packages, like kernel
         msg_run "downgrade" "$NEVRA"
         if [ -n "$CHECK_SCRIPTLETS" ]; then
@@ -687,7 +677,7 @@ case $TEST in
     remove)
         msg_prepare "removing" "$NEVRA"
         pkg_update_to_new_if_present "$NEVRA"
-        pkg_install_new_if_absent "$NEVRA"
+        pkg_install_if_absent "$NEVRA" || exit 1
 
         # OSCI-4333: We have to check again if the package can be removed
         # now after we installed its latest version. It can happen that

--- a/mtps-run-tests
+++ b/mtps-run-tests
@@ -16,6 +16,8 @@
 
 : "${PROG:=${0##*/}}"
 
+EXIT_CODE_SKIP=7
+
 # Source `mtps-setup' from $PATH
 if command -v "mtps-setup" >/dev/null; then source "mtps-setup"; fi
 # If previous fails source `mtps-setup` from this script dir
@@ -205,18 +207,19 @@ for nevra in $nevras_in_repo; do
     ## Ignore errors on rollback due to: https://bugzilla.redhat.com/show_bug.cgi?id=1614346
     ## Rollback fails after Downgrade / Update tests
     #yum -y history rollback "$START" || echo "Ignoring rollback error: RHBZ#1614346"
-    if [ "$test_status" -ne "0" ]; then
+    if [ "$test_status" -eq $EXIT_CODE_SKIP ]; then
+        new_logfname="$(dirname "$logfname")/SKIP-$(basename "$logfname")"
+    elif [ "$test_status" -ne 0 ]; then
         ret=1
         if [ -n "$CRITICAL" ]; then
             new_logfname="$(dirname "$logfname")/FAIL-$(basename "$logfname")"
         else
             new_logfname="$(dirname "$logfname")/WARN-$(basename "$logfname")"
         fi
-        mv "$logfname" "$new_logfname"
     else
         new_logfname="$(dirname "$logfname")/PASS-$(basename "$logfname")"
-        mv "$logfname" "$new_logfname"
     fi
+    mv "$logfname" "$new_logfname"
     if [ -n "$SELINUX" ] && rpm --quiet -q audit; then
         selinux_status=0
         ausearch --format raw -m avc,user_avc,selinux_err,user_selinux_err -ts "$START_DATE" "$START_TIME" 2>&1 | sed -e '/received policyload notice/d' | grep -s -o '^' && selinux_status=1


### PR DESCRIPTION
https://pagure.io/fedora-ci/general/issue/382
https://gitlab.com/testing-farm/oculus/-/issues/18

Ideally, the prepare phase of the downgrade test would do the same, i.e.
first remove package, then try to install the old one and if that fails, skip the test, otherwise update to the new package.
But that'd be 3 operations (remove, install, update) more than what we do now for every package just for a very rare use-case (old package can't be installed).
Now the prep-downgrade does nothing because the previous (update) test leaves the new package installed.

Also,  have separate exit code for skipped tests so that we can distinguish them in the viewer.