### PR TITLE
Disable python36 module on RHEL 8

### DIFF
--- a/mini-tps.spec
+++ b/mini-tps.spec
@@ -1,6 +1,6 @@
 Name: mini-tps
 Version: 0.1
-Release: 168%{?dist}
+Release: 169%{?dist}
 Summary: Mini TPS - Test Package Sanity
 
 License: GPLv2
@@ -64,6 +64,9 @@ install -pD -m 0755 profiles/fedora/prepare-system %{buildroot}%{_libexecdir}/mi
 
 
 %changelog
+* Wed Jan 31 2024 Jiri Popelka <jpopelka@redhat.com> - 0.1-169
+- Disable python36 module on RHEL 8
+
 * Mon Jan 29 2024 Jiri Popelka <jpopelka@redhat.com> - 0.1-168
 - Handle missing compose (id)
 

--- a/profiles/rhel/prepare-system
+++ b/profiles/rhel/prepare-system
@@ -57,8 +57,13 @@ if [ -n "$ENABLE_BUILD_ROOT" ]; then
     yum config-manager --set-enabled "$buildroot_repo"
 fi
 
-# repoquery util acts not on live system, but rather on set of enabled repos. mini-tps hold personal list of protected packages, such as openssh-server
-# yum config-manager --set-enabled astepano-mini-tps || :
+# Disable python36 module on RHEL 8
+RHEL_VER_MAJOR=$(echo "${PROFILE}" | cut -d'-' -f2 | cut -c1)
+if [[ "$RHEL_VER_MAJOR" -eq 8 ]]; then
+  if dnf module list --enabled | grep -q python36; then
+    dnf -y module disable python36
+  fi
+fi
 
 echo "Installing required packages for testing"
 yum -y install createrepo_c which procps-ng


### PR DESCRIPTION
It's enabled by default and prevents us from testing packages it contains (see `dnf info module python36`), e.g. `python3-sqlalchemy`

https://issues.redhat.com/browse/OSCI-5993

I hope (I checked with `repoquery`) it won't break the testing of any other python3 packages because of a dependency on any package in this module.