### PR TITLE
consistently call plain `repoquery`, ensure it is available (#47)

### DIFF
--- a/mtps-get-task
+++ b/mtps-get-task
@@ -784,7 +784,7 @@ fi
 
 # Query packages in the created repo
 nevras_in_repo="$(
-    "$YUMDNFCMD" repoquery \
+    repoquery \
         --qf "%{repoid} %{name}-%{epoch}:%{version}-%{release}.%{arch}" \
         --repo "$repo_name" 2>&1 | \
         sed -n -e "/^${repo_name}[[:space:]]/ s/^${repo_name}[[:space:]]//p"

--- a/profiles/centos-stream/prepare-system
+++ b/profiles/centos-stream/prepare-system
@@ -37,7 +37,7 @@ yum clean all
 yum makecache
 
 echo "Installing packages required for testing..."
-yum -y install createrepo_c which procps-ng
+yum -y install createrepo_c which procps-ng yum-utils
 
 echo "Updating the system..."
 yum -y upgrade

--- a/profiles/fedora/prepare-system
+++ b/profiles/fedora/prepare-system
@@ -56,7 +56,7 @@ echo "Recreating the DNF cache..."
 "$YUMDNFCMD" makecache
 
 echo "Installing packages required for testing..."
-"$YUMDNFCMD" -y install createrepo_c which procps-ng
+"$YUMDNFCMD" -y install createrepo_c which procps-ng dnf-utils
 
 echo "Updating the system..."
 "$YUMDNFCMD" -y upgrade

--- a/profiles/rhel/prepare-system
+++ b/profiles/rhel/prepare-system
@@ -61,7 +61,7 @@ fi
 # yum config-manager --set-enabled astepano-mini-tps || :
 
 echo "Installing required packages for testing"
-yum -y install createrepo_c which procps-ng
+yum -y install createrepo_c which procps-ng yum-utils
 
 yum -y upgrade
 yum clean all


### PR DESCRIPTION
https://github.com/fedora-ci/mini-tps/pull/45 changed two of the three places we try and do a repoquery operation from calling `"$YUMDNFCMD" repoquery` to just calling `repoquery`, but it missed one. This fixes the remaining one. Also, this attempts to ensure the plain `repoquery` command will always be available. It's not safe to assume this, because it's part of dnf-utils (on Fedora) and yum-utils (on EL), it's not part of core dnf/yum, and nothing much else requires it. It does seem to be missing in the environment in which tests on Fedora package pull requests run, for instance, which caused the test to fail on all pull requests until the build with #45 was temporarily removed.