### PR TITLE
fall back on `{dnf,yum} repoquery` if `repoquery` is not present (#47)

### DIFF
--- a/mtps-get-task
+++ b/mtps-get-task
@@ -784,7 +784,7 @@ fi
 
 # Query packages in the created repo
 nevras_in_repo="$(
-    "$YUMDNFCMD" repoquery \
+    "$REPOQUERYCMD" \
         --qf "%{repoid} %{name}-%{epoch}:%{version}-%{release}.%{arch}" \
         --repo "$repo_name" 2>&1 | \
         sed -n -e "/^${repo_name}[[:space:]]/ s/^${repo_name}[[:space:]]//p"

--- a/mtps-pkg-test
+++ b/mtps-pkg-test
@@ -357,7 +357,7 @@ get_old_nevra() {
     local arch="$(from_nevra "$nevra" "arch")"
     # Find previous version of the package.
     local old_nevras=($(
-        repoquery -q "$name"."$arch" --qf="%{name}-%{epoch}:%{version}-%{release}.%{arch}" | \
+        "$REPOQUERYCMD" -q "$name"."$arch" --qf="%{name}-%{epoch}:%{version}-%{release}.%{arch}" | \
         tr -s ' ' | \
         grep "$arch" | \
         sed -n -e "/^${name}-${epoch}:${version}-${release}.${arch}$/"'!p'

--- a/mtps-run-tests
+++ b/mtps-run-tests
@@ -146,7 +146,7 @@ fi
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=584525
 nevras_in_repo="$(
-    repoquery --repoid=${REPONAME} --all \
+    "$REPOQUERYCMD" --repoid=${REPONAME} --all \
         --qf "%{repoid} %{name}-%{epoch}:%{version}-%{release}.%{arch}" 2>&1 | \
         sed -n -e "/^${REPONAME}[[:space:]]/ s/^${REPONAME}[[:space:]]//p"
 )"

--- a/mtps-setup
+++ b/mtps-setup
@@ -60,6 +60,14 @@ if [ -z "$YUMDNFCMD" ]; then
     fi
 fi
 
+# on EL 7, there is no 'yum repoquery', on everything else supported
+# there is 'dnf repoquery' or 'yum repoquery'
+if [ -f "/usr/bin/repoquery" ]; then
+    REPOQUERYCMD="repoquery"
+else
+    REPOQUERYCMD="$YUMDNFCMD repoquery"
+fi
+
 debug() {
     if [[ -n "${DEBUG:-}" || -n "${GB_DEBUG:-}" ]]; then
         echo -e "$*" >&2


### PR DESCRIPTION
https://github.com/fedora-ci/mini-tps/pull/45 changed two out of three places we previously called `"$YUMDNFCMD" repoquery` to instead just call `repoquery` (it missed one). This is because `yum repoquery` doesn't exist on EL 7. However, it's also not really safe to assume the standalone `repoquery` command will always be available either; it's part of yum-utils or dnf-utils and there's no reason to assume that will always be present. This adds a fallback, and consistently uses the command we determine across all three locations.