### PR TITLE
Revert "setenforce fails when running in a container"

### DIFF
--- a/mini-tps.spec
+++ b/mini-tps.spec
@@ -6,7 +6,7 @@
 
 Name: mini-tps
 Version: 0.1
-Release: 174%{?dist}
+Release: 175%{?dist}
 Summary: Mini TPS - Test Package Sanity
 
 License: GPLv2
@@ -73,6 +73,9 @@ install -pD -m 0755 profiles/fedora/prepare-system %{buildroot}%{_libexecdir}/mi
 
 
 %changelog
+* Tue May 21 2024 Jiri Popelka <jpopelka@redhat.com> - 0.1-175
+- revert a SELinux-related change
+
 * Thu May 16 2024 Jiri Popelka <jpopelka@redhat.com> - 0.1-174
 - Add dnf to protected packages
 

--- a/mtps-run-tests
+++ b/mtps-run-tests
@@ -138,7 +138,7 @@ if [ -n "$SELINUX" ]; then
     fi
     if [ -e '/usr/sbin/setenforce' ]; then
         echo "Set selinux enforce to: $SELINUX"
-        setenforce "$SELINUX" || :  # Always return 0 to be able to run/test in a container
+        setenforce "$SELINUX"
     else
         debug "Skipping setenforce. 'setenforce' command is part of libselinux-utils package."
     fi


### PR DESCRIPTION
There have been quite a lot of AVCs in the recent Fedora installability pipeline jobs.
91d6d70d is the only SELinux-related change that comes to my mind.