### PR TITLE
Ignore (bogus?) warnings about removed systemd unit files being changed on disk and needing to be reloaded

### DIFF
--- a/mini-tps.spec
+++ b/mini-tps.spec
@@ -6,7 +6,7 @@
 
 Name: mini-tps
 Version: 0.1
-Release: 179%{?dist}
+Release: 180%{?dist}
 Summary: Mini TPS - Test Package Sanity
 
 License: GPLv2
@@ -73,6 +73,9 @@ install -pD -m 0755 profiles/fedora/prepare-system %{buildroot}%{_libexecdir}/mi
 
 
 %changelog
+* Mon Jul 1 2024 Michal Srb <michal@redhat.com> - 0.1-180
+- Temporarily ignore warnings about removed systemd unit files being changed on disk
+
 * Tue Jun 18 2024 Jiri Popelka <jpopelka@redhat.com> - 0.1-179
 - Use dnf5 if installed
 

--- a/mtps-pkg-test
+++ b/mtps-pkg-test
@@ -149,6 +149,10 @@ run_with_scriptlet_check() {
                 #  Ignore warning about UID being outside of the SYS_UID_MIN/SYS_UID_MAX range.
                 #  This is a "known unfixable". See comments in OSCI-4825 for more information.
                 grep -P -v -i 'useradd warning: [^ ]+ uid [0-9]+ outside of the SYS_UID_MIN [0-9]+ and SYS_UID_MAX [0-9]+ range\.' "$output_part" > "${output_part}-filtered" && mv "${output_part}-filtered" "$output_part"
+                #  Ignore (bogus?) warnings about removed systemd unit files being changed on disk and needing to be reloaded.
+                #  This seems to be a bug in systemd(?): https://github.com/systemd/systemd/issues/32959
+                #  TODO: Remove this once systemd gets updated and the problem is no longer present
+                grep -P -v -i "warning: the unit file, source configuration file or drop-ins of .* changed on disk\. run 'systemctl daemon-reload' to reload units\." "$output_part" > "${output_part}-filtered" && mv "${output_part}-filtered" "$output_part"
 
                 # We only look for the following problematic words (case-insensitive):
                 # * error


### PR DESCRIPTION
This seems to be a bug in systemd. See the comment in the code.