### PR TITLE
Workaround for yum v3.4.3 downgrade test

### DIFF
--- a/mtps-pkg-test
+++ b/mtps-pkg-test
@@ -461,7 +461,16 @@ pkg_downgrade_to_old() {
         return 1
     fi
     # dnf returns 1 if no downgrade available
-    "$YUMDNFCMD" -y downgrade "$ALLOWERASING" "$name"
+    if [[ "$YUMDNFCMD" == "yum" ]]; then
+      # yum v3.4.3 has trouble resolving dependencies. Specify all what's installed from brew-$TASK_ID to workaround
+      installed_pkgs=()
+      while IFS= read -r package; do
+        installed_pkgs+=("$package")
+      done < <("$YUMDNFCMD" list installed | awk '/@brew-'${TASK_ID}'/ {print $1}')
+      "$YUMDNFCMD" -y downgrade "$name" "${installed_pkgs[@]}"
+    else
+      "$YUMDNFCMD" -y downgrade "$ALLOWERASING" "$name"
+    fi
 }
 
 box_out() {


### PR DESCRIPTION
RHEL 7 has yum v3.4.3. As far as I understood, a downgrade on that version is failing to successfully resolve dependencies available in multiple repos by itself, which results in an error, e.g:

```
Error: Package: freeradius-utils-3.0.13-15.el7.x86_64 (rhel-opt)
           Requires: freeradius = 3.0.13-15.el7
           Installed: freeradius-3.0.13-15.el7_9.1.x86_64 (@brew-62705510)
               freeradius = 3.0.13-15.el7_9.1
           Available: freeradius-3.0.13-15.el7.x86_64 (rhel)
               freeradius = 3.0.13-15.el7
```
This MR workarounds the issue by adding list of all installed content from the tested task repo to the downgrade command.