### PR TITLE
Enable `crb` and `epel` for centos-stream testing

### DIFF
--- a/profiles/centos-stream/prepare-system
+++ b/profiles/centos-stream/prepare-system
@@ -39,5 +39,9 @@ yum makecache
 echo "Installing packages required for testing..."
 yum -y install createrepo_c which procps-ng yum-utils
 
+echo "Enabling crb and epel"
+yum config-manager --enable crb
+yum -y install epel-release
+
 echo "Updating the system..."
 yum -y upgrade


### PR DESCRIPTION
These are necessary so that Fedora CI pull requests against `epel9` are working. Related links:

 * https://issues.redhat.com/browse/OSCI-6783
 * https://src.fedoraproject.org/rpms/tmt/pull-request/142