### PR TITLE
viewer: ignore UTF-8 errors

### DIFF
--- a/viewer/generate-result-json
+++ b/viewer/generate-result-json
@@ -50,7 +50,8 @@ for log in mtps_log_dir.iterdir():
         {
             "result": RESULTS_MAPPING[result],
             "message": f"{test_name}: {test_object}" if test_object else test_name,
-            "details": log.read_text(),
+            # dnf5 can print invalid UTF characters due to https://github.com/rpm-software-management/dnf5/issues/1865
+            "details": log.read_text(errors="replace"),
         }
     )
 


### PR DESCRIPTION
Due to a bug in dnf invalid UTF-8, make sure the viewer does not choke on them.

See:

https://github.com/rpm-software-management/dnf5/issues/1865

for details.

Example of the failure from
https://artifacts.dev.testing-farm.io/c7a1bbdd-1c91-44a9-87ba-f2b9f6fe7dc3/:

```
18:24:51                 out: Running transaction
18:24:51                 out: [1/2] Prepare transaction               100% |  62.0   B/s |   1.0   B |  00m00s
18:24:51                 out: [2/2] Removing spamassassin-debugsource 100% | 147.0   B/s |   9.0   B |  00m00s
18:24:51                 out: Complete!
18:24:51                 out: remove result: fail (status code: 1)
18:24:51                 out: Traceback (most recent call last):
18:24:51                 out:   File "/usr/libexec/mini-tps/viewer/generate-result-json", line 53, in <module>
18:24:51                 out:     "details": log.read_text(),
18:24:51                 out:                ~~~~~~~~~~~~~^^
18:24:51                 out:   File "/usr/lib64/python3.13/pathlib/_local.py", line 546, in read_text
18:24:51                 out:     return PathBase.read_text(self, encoding, errors, newline)
18:24:51                 out:            ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
18:24:51                 out:   File "/usr/lib64/python3.13/pathlib/_abc.py", line 633, in read_text
18:24:51                 out:     return f.read()
18:24:51                 out:            ~~~~~~^^
18:24:51                 out:   File "<frozen codecs>", line 325, in decode
18:24:51                 out: UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 19977-19978: invalid continuation byte
18:24:51                 out: running in TMT, wrote /var/ARTIFACTS/work-installability513gxf67/installability/execute/data/guest/default-0/installability-2/data/results.yaml
18:24:51                 out: mtps-run-tests overall result: fail (status code: 1)
18:24:51                 out: Shared connection to 18.221.80.14 closed.
```