### PR TITLE
OSCI-9588: Fix repo URL for promoted draft builds

### DIFF
--- a/mini-tps.spec
+++ b/mini-tps.spec
@@ -6,7 +6,7 @@
 
 Name: mini-tps
 Version: 0.1
-Release: 193%{?dist}
+Release: 194%{?dist}
 Summary: Mini TPS - Test Package Sanity
 
 License: GPLv2
@@ -79,6 +79,9 @@ install -pD -m 0755 profiles/fedora/prepare-system %{buildroot}%{_libexecdir}/mi
 
 
 %changelog
+* Fri Apr 10 2026 Chris Kelley <ckelley@redhat.com> - 0.1-194
+- Fix bug with incorrectly constructed URL for promoted drafts
+
 * Tue Mar 24 2026 Michal Srb <michal@redhat.com> - 0.1-193
 - Improve RHEL 6 compatibility - fix shebangs
 

--- a/mtps-get-builds
+++ b/mtps-get-builds
@@ -198,8 +198,10 @@ mk_url() {
     local rel
     rel="$(from_rpm_name "$srpm" "rel")"
     if [ "$is_draft" == "yes" ] && [ -n "$nvr" ]; then
-        # Only append draft part if it's not already in the release
-        if [[ "$rel" != *,draft_* ]]; then
+        # Only append draft part if it's not already in the release, and the NVR
+        # still carries ",draft_<id>" (promoted drafts strip that suffix but may stay
+        # draft=yes; those use the normal release path only).
+        if [[ "$rel" != *,draft_* && "$nvr" == *,draft_* ]]; then
             rel="$rel",draft_${nvr#*,draft_}
         fi
     fi

--- a/mtps-get-task
+++ b/mtps-get-task
@@ -558,7 +558,11 @@ mk_url() {
         ver="$(from_rpm_name "${srpm_filename}" "ver")"
         rel="$(from_rpm_name "${srpm_filename}" "rel")"
         if [ "$is_draft" == "yes" ]; then
-            rel="$rel",draft_${nvr#*,draft_}
+            # Promoted drafts are still draft=yes in Brew while the NVR no longer
+            # contains ",draft_<id>"; RPMs are then under the normal release path.
+            if [[ "$nvr" == *,draft_* ]]; then
+                rel="$rel",draft_${nvr#*,draft_}
+            fi
         fi
         arch="$(from_rpm_name "${filename}" "arch")"
         # https://download.devel.redhat.com/brewroot/packages/curl/7.61.1/34.el8/x86_64/curl-7.61.1-34.el8.x86_64.rpm


### PR DESCRIPTION
Promoted draft builds are still draft builds according to Brew, so we cannot just attempt to parse the draft suffix assuming it will exist, as it has been stripped from promoted builds.