### PR TITLE
Update mtps to be compatible with rhel-6

### DIFF
--- a/mtps-get-builds
+++ b/mtps-get-builds
@@ -36,7 +36,7 @@ build_rpms_info2rpms() {
 build_rpms_info2buid_id() {
     local xml="$1" && shift  # listBuildRPMs response
     local build_id=
-    build_id="$(echo "$xml" | xmllint --xpath 'string(//member[name="build_id"]/value/int/text())' -)"
+    build_id="$(xml_get_value "$xml" '//member[name="build_id"]/value/int/text()')"
     debug "Brew build id: $build_id"
     echo "$build_id"
 }
@@ -98,7 +98,7 @@ EOF
 build2is_draft() {
     local xml="$1" && shift
     local is_draft
-    is_draft="$(echo "$xml" | xmllint --xpath 'string(//member[name="draft"]/value/boolean/text())' -)"
+    is_draft="$(xml_get_value "$xml" '//member[name="draft"]/value/boolean/text()')"
     [[ "$is_draft" == '1' ]] && is_draft="yes" || is_draft="no"
     debug "Is draft: $is_draft"
     echo "$is_draft"
@@ -107,7 +107,7 @@ build2is_draft() {
 build2nvr() {
     local xml="$1" && shift
     local nvr
-    nvr="$(echo "$xml" | xmllint --xpath 'string(//member[name="nvr"]/value/string/text())' -)"
+    nvr="$(xml_get_value "$xml" '//member[name="nvr"]/value/string/text()')"
     debug "NVR: $nvr"
     echo "$nvr"
 }
@@ -236,7 +236,7 @@ download_rpm() {
         return
     fi
     mkdir -p "$GB_REPODIR"
-    GB_REPODIR="$(realpath "$GB_REPODIR")"
+    GB_REPODIR="$(readlink -f "$GB_REPODIR")"
     pushd "$GB_REPODIR" > /dev/null
     curl --retry 5 --insecure --fail --location --show-error --remote-name --remote-header-name "$url"
     popd > /dev/null
@@ -312,7 +312,7 @@ if [ -z "$GB_BUILD" ]; then
 fi
 
 mkdir -p "${LOGS_DIR:=mtps-logs}"
-LOGS_DIR="$(realpath "$LOGS_DIR")"
+LOGS_DIR="$(readlink -f "$LOGS_DIR")"
 while true; do
     TESTRUN_ID="$(date +%H%M%S)"
     logfname="${LOGS_DIR%%/}/${TESTRUN_ID}-${GB_BUILD}-mtps-get-builds.log"

--- a/mtps-get-module
+++ b/mtps-get-module
@@ -37,7 +37,7 @@ builds_from_answer() {
 build2id() {
     local xml="$1" && shift
     local build_id
-    build_id="$(echo "$xml" | xmllint --xpath 'string(//member[name="build_id"]/value/int/text())' -)"
+    build_id="$(xml_get_value "$xml" '//member[name="build_id"]/value/int/text()')"
     debug "Brew build id: $build_id"
     echo "$build_id"
 }
@@ -45,7 +45,7 @@ build2id() {
 build2tag() {
     local xml="$1" && shift
     local brew_tag
-    brew_tag="$(echo "$xml" | xmllint --xpath 'string(//member[name="content_koji_tag"]/value/string/text())' -)"
+    brew_tag="$(xml_get_value "$xml" '//member[name="content_koji_tag"]/value/string/text()')"
     debug "Brew tag: $brew_tag"
     echo "$brew_tag"
 }
@@ -194,7 +194,7 @@ download_artifact() {
     local url="$1" && shift
     local dstdir="$1" && shift
     mkdir -p "$dstdir"
-    dstdir="$(realpath "$dstdir")"
+    dstdir="$(readlink -f "$dstdir")"
     pushd "$dstdir" > /dev/null
     curl --retry 5 --insecure --fail --location --show-error --remote-name --remote-header-name "$url"
     popd > /dev/null
@@ -389,7 +389,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 mkdir -p "${LOGS_DIR:=mtps-logs}"
-LOGS_DIR="$(realpath "$LOGS_DIR")"
+LOGS_DIR="$(readlink -f "$LOGS_DIR")"
 while true; do
     TESTRUN_ID="$(date +%H%M%S)"
     logfname="${LOGS_DIR%%/}/${TESTRUN_ID}-${MBSID}-mtps-get-module.log"
@@ -541,7 +541,7 @@ if [[ -z "$CREATEREPO" || ! -d "$REPODIR" ]]; then
     exit 0
 fi
 
-REPODIR="$(realpath "$REPODIR")"
+REPODIR="$(readlink -f "$REPODIR")"
 
 which 'createrepo' >/dev/null 2>&1 && CREATEREPO_BIN="createrepo" || :
 which 'createrepo_c' >/dev/null 2>&1 && CREATEREPO_BIN="createrepo_c" || :

--- a/mtps-get-task
+++ b/mtps-get-task
@@ -55,7 +55,7 @@ task_result2srpm() {
 task_request2is_scratch() {
     local xml="$1" && shift
     local is_scratch
-    is_scratch="$(echo "$xml" | xmllint --xpath 'string(//member[name="scratch"]/value/boolean/text())' -)"
+    is_scratch="$(xml_get_value "$xml" '//member[name="scratch"]/value/boolean/text()')"
     [[ "$is_scratch" == '1' ]] && is_scratch="yes" || is_scratch="no"
     debug "Is scratch: $is_scratch"
     echo "$is_scratch"
@@ -64,7 +64,7 @@ task_request2is_scratch() {
 task_request2is_draft() {
     local xml="$1" && shift
     local is_draft
-    is_draft="$(echo "$xml" | xmllint --xpath 'string(//member[name="draft"]/value/boolean/text())' -)"
+    is_draft="$(xml_get_value "$xml" '//member[name="draft"]/value/boolean/text()')"
     [[ "$is_draft" == '1' ]] && is_draft="yes" || is_draft="no"
     debug "Is draft: $is_draft"
     echo "$is_draft"
@@ -73,7 +73,7 @@ task_request2is_draft() {
 build2volume_name() {
     local xml="$1" && shift
     local volume_name
-    volume_name="$(echo "$xml" | xmllint --xpath 'string(//member[name="volume_name"]/value/string/text())' -)"
+    volume_name="$(xml_get_value "$xml" '//member[name="volume_name"]/value/string/text()')"
     debug "Volume name: $volume_name"
     echo "$volume_name"
 }
@@ -81,7 +81,7 @@ build2volume_name() {
 build2build_source() {
     local xml="$1" && shift
     local build_source
-    build_source="$(echo "$xml" | xmllint --xpath 'string(//member[name="source"]/value/string/text())' -)"
+    build_source="$(xml_get_value "$xml" '//member[name="source"]/value/string/text()')"
     debug "Build source: $build_source"
     echo "$build_source"
 }
@@ -89,7 +89,7 @@ build2build_source() {
 builds2nvr() {
     local xml="$1" && shift
     local nvr
-    nvr="$(echo "$xml" | xmllint --xpath 'string(//member[name="nvr"]/value/string/text())' -)"
+    nvr="$(xml_get_value "$xml" '//member[name="nvr"]/value/string/text()')"
     debug "NVR: $nvr"
     echo "$nvr"
 }
@@ -97,7 +97,7 @@ builds2nvr() {
 builds2build_id() {
     local xml="$1" && shift
     local buildid
-    buildid="$(echo "$xml" | xmllint --xpath 'string(//member[name="build_id"]/value/int/text())' -)"
+    buildid="$(xml_get_value "$xml" '//member[name="build_id"]/value/int/text()')"
     debug "build id: $buildid"
     echo "$buildid"
 }
@@ -105,7 +105,7 @@ builds2build_id() {
 builds2is_draft() {
     local xml="$1" && shift
     local is_draft
-    is_draft="$(echo "$xml" | xmllint --xpath 'string(//member[name="draft"]/value/boolean/text())' -)"
+    is_draft="$(xml_get_value "$xml" '//member[name="draft"]/value/boolean/text()')"
     [[ "$is_draft" == '1' ]] && is_draft="yes" || is_draft="no"
     debug "Is draft: $is_draft"
     echo "$is_draft"
@@ -539,7 +539,7 @@ download_rpm() {
         return
     fi
     mkdir -p "$REPODIR"
-    REPODIR="$(realpath "$REPODIR")"
+    REPODIR="$(readlink -f "$REPODIR")"
     pushd "$REPODIR" > /dev/null
     curl --retry 5 --insecure --fail --location --show-error --remote-name --remote-header-name "$url"
     popd > /dev/null
@@ -666,7 +666,7 @@ if [ -z "$TASK" ]; then
 fi
 
 mkdir -p "${LOGS_DIR:=mtps-logs}"
-LOGS_DIR="$(realpath "$LOGS_DIR")"
+LOGS_DIR="$(readlink -f "$LOGS_DIR")"
 while true; do
     TESTRUN_ID="$(date +%H%M%S)"
     logfname="${LOGS_DIR%%/}/${TESTRUN_ID}-${TASK}-mtps-get-task.log"

--- a/mtps-mutils
+++ b/mtps-mutils
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # NOTE: if mini-tps is packaged and built for RHEL 8, which comes with the platform python,
 # the shebang above will turn into "#!/usr/libexec/platform-python" automatically.
 

--- a/mtps-mutils
+++ b/mtps-mutils
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 # NOTE: if mini-tps is packaged and built for RHEL 8, which comes with the platform python,
 # the shebang above will turn into "#!/usr/libexec/platform-python" automatically.
 

--- a/mtps-pkg-test
+++ b/mtps-pkg-test
@@ -99,7 +99,25 @@ nevra_older_then() {
     local rcmp
     # https://rpm-software-management.github.io/rpm/manual/lua
     # rpm.vercmp(v1, v2) returns -1, 0 or 1 if v1 is smaller, equal or larger than v2
-    rcmp="$(rpm --define "pkg1 $nevra1" --define "pkg2 $nevra2"  --eval '%{lua: print(rpm.vercmp(rpm.expand("%pkg1"), rpm.expand("%pkg2")))}')"
+    if rpm --eval '%{lua: print(rpm.vercmp("a","b"))}' >/dev/null 2>&1; then
+        # RPM supports Lua vercmp (RHEL 7+)
+        rcmp="$(rpm --define "pkg1 $nevra1" --define "pkg2 $nevra2"  --eval '%{lua: print(rpm.vercmp(rpm.expand("%pkg1"), rpm.expand("%pkg2")))}')"
+    elif command -v rpmdev-vercmp >/dev/null 2>&1; then
+        # Fallback to rpmdev-vercmp (RHEL 6)
+        # rpmdev-vercmp exits with 11 if arg1 < arg2, 12 if arg1 > arg2, 0 if equal
+        local rc=0
+        rpmdev-vercmp "$nevra1" "$nevra2" >/dev/null 2>&1 || rc=$?
+        if [[ "$rc" -eq 11 ]]; then
+            rcmp="-1"
+        elif [[ "$rc" -eq 12 ]]; then
+            rcmp="1"
+        else
+            rcmp="0"
+        fi
+    else
+        echo "Error: No version comparison tool available (need rpm with Lua vercmp or rpmdev-vercmp)" >&2
+        exit 1
+    fi
     if [[ "$rcmp" == "-1" ]]; then
         # True
         return 0

--- a/mtps-setup
+++ b/mtps-setup
@@ -75,3 +75,18 @@ debug() {
         echo -e "$*" >&2
     fi
 }
+
+# Portable xmllint helper: extracts a single text value via XPath.
+# Works with xmllint --shell (available since RHEL 6) instead of --xpath (RHEL 7+).
+# Usage: xml_get_value "$xml_string" "//member[name='foo']/value/string/text()"
+xml_get_value() {
+    local xml="$1" && shift
+    local xpath="$1" && shift
+    local tmpfile
+    tmpfile="$(mktemp)"
+    echo "$xml" > "$tmpfile"
+    local result
+    result="$(echo "cat $xpath" | xmllint --shell "$tmpfile" | sed -n -e '/^[[:alnum:]]/p')"
+    rm -f "$tmpfile"
+    echo "$result"
+}

--- a/mtps-tag
+++ b/mtps-tag
@@ -44,7 +44,7 @@ tagged2nvrs() {
 tag_info2tag_id() {
     local xml="$1" && shift
     local task=
-    tag_id="$(echo "$xml" | xmllint --xpath 'string(//member[name="id"]/value/int/text())' -)"
+    tag_id="$(xml_get_value "$xml" '//member[name="id"]/value/int/text()')"
     debug "Tag name: $tag_id"
     echo "$tag_id"
 }

--- a/viewer/generate-result-json
+++ b/viewer/generate-result-json
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 

--- a/viewer/generate-result-json
+++ b/viewer/generate-result-json
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 


### PR DESCRIPTION
#### Summary

1.   Replace realpath with readlink -f for RHEL 6 compatibility (coreutils 8.4 lacks realpath)
2.   Replace xmllint --xpath with a portable xml_get_value() helper using xmllint --shell (RHEL 6's libxml2 2.7.6 lacks --xpath)
3.   Add rpmdev-vercmp fallback for RPM version comparison when rpm.vercmp() Lua API is unavailable (added in RPM 4.15, RHEL 6 ships 4.8)

#### Regression risk

1. readlink -f: Drop-in replacement, identical semantics on all RHEL versions.
2. xml_get_value(): Uses the same xmllint --shell + sed pattern already proven in 17 existing call sites in the same scripts.
3. rpmdev-vercmp fallback: The rpm.vercmp() path is tried first, so RHEL 7+ behavior is unchanged. Fallback only activates on systems where rpm.vercmp() is not available.

### Detailed analysis
https://docs.google.com/document/d/1sNSgznQa2Ydv_W6U2TjCJHiUOgulf4ROH_KbASNbq7Q 