### PR TITLE
List only completed builds

### DIFF
--- a/mtps-get-task
+++ b/mtps-get-task
@@ -198,7 +198,7 @@ EOF
 }
 
 brew_list_builds() {
-    # listBuilds query
+    # listBuilds query - state 1 is koji.BUILD_STATES 'COMPLETE'
     local task="$1" && shift
     local query="$(cat << EOF
 <?xml version='1.0'?>
@@ -214,6 +214,10 @@ brew_list_builds() {
         <member>
           <name>taskID</name>
           <value><int>$task</int></value>
+        </member>
+        <member>
+          <name>state</name>
+          <value><int>1</int></value>
         </member>
       </struct></value>
     </param>


### PR DESCRIPTION
example:
```
$ brew list-builds --task=70721647
Build                                                    Built by          State
-------------------------------------------------------  ----------------  ----------------
dovecot-2.3.16-8.el9_2.2,draft_4010651                   osci-distrobuildsync  BUILDING
dovecot-2.3.16-8.el9_2.2,draft_4010653                   osci-distrobuildsync  COMPLETE

$ brew list-builds --task=70721647 --state=1
Build                                                    Built by          State
-------------------------------------------------------  ----------------  ----------------
dovecot-2.3.16-8.el9_2.2,draft_4010653                   osci-distrobuildsync  COMPLETE
```
https://artifacts.osci.redhat.com/testing-farm/10c7ac89-22b8-4231-b979-00dd4b118f72/