### PR TITLE
Ensure we get only one value - OSCI-9799

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ change from a (yet unmerged) pull request in those pipelines:
 
 #### Fedora
 
-- Replace `dnf -y copr enable @osci/mini-tps` with `dnf -y copr enable packit/fedora-ci-mini-tps-<PR-number>`
-  in [prepare.sh](https://github.com/fedora-ci/installability-pipeline/blob/master/prepare.sh#L13)
+- Replace `@osci/mini-tps` with `packit/fedora-ci-mini-tps-<PR-number>`
+  in [installability.fmf](https://github.com/fedora-ci/installability-pipeline/blob/d3ee1ae6c38b0b8d4261ef57b6c48cc64484d5d9/installability.fmf#L12)
   and open a PR in the [repo](https://github.com/fedora-ci/installability-pipeline).
 - Once the PR appears in [pipelines for PRs](https://osci-jenkins-1.ci.fedoraproject.org/job/fedora-ci/job/installability-pipeline/view/change-requests/), submit `Build with Parameters`.
 
 #### RHEL
 
-- Replace [repo url](https://gitlab.cee.redhat.com/osci-pipelines/installability-pipeline/-/blob/ae25435bb668a59e431e2bc33ff299839023f11d/prepare.sh#L34)
+- Replace [repo url](https://gitlab.cee.redhat.com/osci-pipelines/installability-pipeline/-/blob/80a3b0972d8f00e1bed2d4740d5a51839ed7d107/prepare.sh#L47)
   with `https://copr.fedorainfracloud.org/coprs/packit/fedora-ci-mini-tps-<PR-number>/repo/epel-${EPEL_VERSION}` and open an MR in the
   [repo](https://gitlab.cee.redhat.com/osci-pipelines/installability-pipeline).
 - Once the MR appears in [pipelines for MRs](https://jenkins.prod.osci.redhat.com/job/OSCI-Pipelines/job/osci-pipelines%252Finstallability-pipeline/view/change-requests/),

--- a/mtps-get-builds
+++ b/mtps-get-builds
@@ -33,7 +33,7 @@ build_rpms_info2rpms() {
 build_rpms_info2buid_id() {
     local xml="$1" && shift  # listBuildRPMs response
     local build_id=
-    build_id="$(xml_get_value "$xml" '//member[name="build_id"]/value/int/text()')"
+    build_id="$(xml_get_value "$xml" '//member[name="build_id"]/value/int/text()' | head -1)"
     debug "Brew build id: $build_id"
     echo "$build_id"
 }
@@ -95,7 +95,7 @@ EOF
 build2is_draft() {
     local xml="$1" && shift
     local is_draft
-    is_draft="$(xml_get_value "$xml" '//member[name="draft"]/value/boolean/text()')"
+    is_draft="$(xml_get_value "$xml" '//member[name="draft"]/value/boolean/text()' | head -1)"
     [[ "$is_draft" == '1' ]] && is_draft="yes" || is_draft="no"
     debug "Is draft: $is_draft"
     echo "$is_draft"
@@ -104,7 +104,7 @@ build2is_draft() {
 build2nvr() {
     local xml="$1" && shift
     local nvr
-    nvr="$(xml_get_value "$xml" '//member[name="nvr"]/value/string/text()')"
+    nvr="$(xml_get_value "$xml" '//member[name="nvr"]/value/string/text()' | head -1)"
     debug "NVR: $nvr"
     echo "$nvr"
 }

--- a/mtps-get-module
+++ b/mtps-get-module
@@ -34,7 +34,7 @@ builds_from_answer() {
 build2id() {
     local xml="$1" && shift
     local build_id
-    build_id="$(xml_get_value "$xml" '//member[name="build_id"]/value/int/text()')"
+    build_id="$(xml_get_value "$xml" '//member[name="build_id"]/value/int/text()' | head -1)"
     debug "Brew build id: $build_id"
     echo "$build_id"
 }
@@ -42,7 +42,7 @@ build2id() {
 build2tag() {
     local xml="$1" && shift
     local brew_tag
-    brew_tag="$(xml_get_value "$xml" '//member[name="content_koji_tag"]/value/string/text()')"
+    brew_tag="$(xml_get_value "$xml" '//member[name="content_koji_tag"]/value/string/text()' | head -1)"
     debug "Brew tag: $brew_tag"
     echo "$brew_tag"
 }
@@ -50,7 +50,7 @@ build2tag() {
 build2owner() {
     local xml="$1" && shift
     local owner
-    owner="$(xml_get_value "$xml" '//member[name="owner_name"]/value/string/text()')"
+    owner="$(xml_get_value "$xml" '//member[name="owner_name"]/value/string/text()' | head -1)"
     debug "Context generated build in Brew has owner name:\n${owner}\n---"
     echo "$owner"
 }
@@ -58,7 +58,7 @@ build2owner() {
 build2name() {
     local xml="$1" && shift
     local name
-    name="$(xml_get_value "$xml" '//member[name="package_name"]/value/string/text()')"
+    name="$(xml_get_value "$xml" '//member[name="package_name"]/value/string/text()' | head -1)"
     debug "Module name:\n${name}\n---"
     echo "$name"
 }
@@ -66,7 +66,7 @@ build2name() {
 build2nvr() {
     local xml="$1" && shift
     local nvr
-    nvr="$(xml_get_value "$xml" '//member[name="nvr"]/value/string/text()')"
+    nvr="$(xml_get_value "$xml" '//member[name="nvr"]/value/string/text()' | head -1)"
     debug "Module NVR for context build in Brew:\n${nvr}\n---"
     echo "$nvr"
 }

--- a/mtps-get-task
+++ b/mtps-get-task
@@ -38,7 +38,7 @@ task_result2rpms() {
 task_result2srpm() {
     local xml="$1" && shift
     local srpm
-    srpm="$(xml_get_value "$xml" '//member[name="srpms"]//value/string/text()' | sed -n -e "/\.rpm/p")"
+    srpm="$(xml_get_value "$xml" '//member[name="srpms"]//value/string/text()' | sed -n -e "/\.rpm/p" | head -1)"
     # e.g. tasks/3126/110193126/keyutils-1.6.3-1.fc40.src.rpm. Don't strip the prefix off here, we need it.
     debug "srpm: ${srpm}\n---"
     echo "$srpm"
@@ -47,7 +47,7 @@ task_result2srpm() {
 task_request2is_scratch() {
     local xml="$1" && shift
     local is_scratch
-    is_scratch="$(xml_get_value "$xml" '//member[name="scratch"]/value/boolean/text()')"
+    is_scratch="$(xml_get_value "$xml" '//member[name="scratch"]/value/boolean/text()' | head -1)"
     [[ "$is_scratch" == '1' ]] && is_scratch="yes" || is_scratch="no"
     debug "Is scratch: $is_scratch"
     echo "$is_scratch"
@@ -56,7 +56,7 @@ task_request2is_scratch() {
 task_request2is_draft() {
     local xml="$1" && shift
     local is_draft
-    is_draft="$(xml_get_value "$xml" '//member[name="draft"]/value/boolean/text()')"
+    is_draft="$(xml_get_value "$xml" '//member[name="draft"]/value/boolean/text()' | head -1)"
     [[ "$is_draft" == '1' ]] && is_draft="yes" || is_draft="no"
     debug "Is draft: $is_draft"
     echo "$is_draft"
@@ -65,7 +65,7 @@ task_request2is_draft() {
 build2volume_name() {
     local xml="$1" && shift
     local volume_name
-    volume_name="$(xml_get_value "$xml" '//member[name="volume_name"]/value/string/text()')"
+    volume_name="$(xml_get_value "$xml" '//member[name="volume_name"]/value/string/text()' | head -1)"
     debug "Volume name: $volume_name"
     echo "$volume_name"
 }
@@ -73,7 +73,7 @@ build2volume_name() {
 build2build_source() {
     local xml="$1" && shift
     local build_source
-    build_source="$(xml_get_value "$xml" '//member[name="source"]/value/string/text()')"
+    build_source="$(xml_get_value "$xml" '//member[name="source"]/value/string/text()' | head -1)"
     debug "Build source: $build_source"
     echo "$build_source"
 }
@@ -81,7 +81,7 @@ build2build_source() {
 builds2nvr() {
     local xml="$1" && shift
     local nvr
-    nvr="$(xml_get_value "$xml" '//member[name="nvr"]/value/string/text()')"
+    nvr="$(xml_get_value "$xml" '//member[name="nvr"]/value/string/text()' | head -1)"
     debug "NVR: $nvr"
     echo "$nvr"
 }
@@ -89,15 +89,15 @@ builds2nvr() {
 builds2build_id() {
     local xml="$1" && shift
     local buildid
-    buildid="$(xml_get_value "$xml" '//member[name="build_id"]/value/int/text()')"
-    debug "build id: $buildid"
+    buildid="$(xml_get_value "$xml" '//member[name="build_id"]/value/int/text()' | head -1)"
+    debug "Build id: $buildid"
     echo "$buildid"
 }
 
 builds2is_draft() {
     local xml="$1" && shift
     local is_draft
-    is_draft="$(xml_get_value "$xml" '//member[name="draft"]/value/boolean/text()')"
+    is_draft="$(xml_get_value "$xml" '//member[name="draft"]/value/boolean/text()' | head -1)"
     [[ "$is_draft" == '1' ]] && is_draft="yes" || is_draft="no"
     debug "Is draft: $is_draft"
     echo "$is_draft"
@@ -309,7 +309,7 @@ EOF
 taskinfo2owner() {
     local xml="$1" && shift
     local owner
-    owner="$(xml_get_value "$xml" '//member[name="owner"]/value/int/text()')"
+    owner="$(xml_get_value "$xml" '//member[name="owner"]/value/int/text()' | head -1)"
     debug "Task owner id:\n${owner}\n---"
     echo "$owner"
 }
@@ -317,7 +317,7 @@ taskinfo2owner() {
 taskinfo2method() {
     local xml="$1" && shift
     local method
-    method="$(xml_get_value "$xml" '//member[name="method"]/value/string/text()')"
+    method="$(xml_get_value "$xml" '//member[name="method"]/value/string/text()' | head -1)"
     debug "Method:\n${method}\n---"
     echo "$method"
 }
@@ -325,7 +325,7 @@ taskinfo2method() {
 task_request2target() {
     local xml="$1" && shift
     local target
-    target="$(xml_get_value "$xml" '//params/param[1]/value/array/data[1]/value[2]/string/text()')"
+    target="$(xml_get_value "$xml" '//params/param[1]/value/array/data[1]/value[2]/string/text()' | head -1)"
     debug "Task target:\n${target}\n---"
     echo "$target"
 }
@@ -349,7 +349,7 @@ build_rpms_info2rpms() {
 ownerinfo2user() {
     local xml="$1" && shift
     local owner
-    owner="$(xml_get_value "$xml" '//member[name="name"]/value/string/text()')"
+    owner="$(xml_get_value "$xml" '//member[name="name"]/value/string/text()' | head -1)"
     debug "Task owner name:\n${owner}\n---"
     echo "$owner"
 }
@@ -357,7 +357,7 @@ ownerinfo2user() {
 ownerinfo2krb() {
     local xml="$1" && shift
     local email
-    email="$(xml_get_value "$xml" '//member[name="krb_principal"]/value/string/text()')"
+    email="$(xml_get_value "$xml" '//member[name="krb_principal"]/value/string/text()' | head -1)"
     debug "Task owner kerberos:\n${email}\n---"
     echo "$email"
 }

--- a/mtps-tag
+++ b/mtps-tag
@@ -40,7 +40,7 @@ tagged2nvrs() {
 tag_info2tag_id() {
     local xml="$1" && shift
     local task=
-    tag_id="$(xml_get_value "$xml" '//member[name="id"]/value/int/text()')"
+    tag_id="$(xml_get_value "$xml" '//member[name="id"]/value/int/text()' | head -1)"
     debug "Tag name: $tag_id"
     echo "$tag_id"
 }


### PR DESCRIPTION
Before 51c155ee, some of those functions used `xmllint --xpath 'string(...)'`,
which returns the string value of only the first node.
With `xmllint --shell`, we output all matching nodes.
With this commit, we explicitly take only the first value with `| head -1`.