### PR TITLE
Implement scriptlet check for pkg_remove_any in prepare phase

### DIFF
--- a/mtps-pkg-test
+++ b/mtps-pkg-test
@@ -640,7 +640,11 @@ fi
 case $TEST in
     install)
         msg_prepare "installing" "$NEVRA"
-        pkg_remove_any "$NEVRA"
+        if [ -n "$CHECK_SCRIPTLETS" ]; then
+            run_with_scriptlet_check pkg_remove_any "$NEVRA"
+        else
+            pkg_remove_any "$NEVRA"
+        fi
         msg_run "install" "$NEVRA"
         if [ -n "$CHECK_SCRIPTLETS" ]; then
             run_with_scriptlet_check pkg_install_if_absent "$NEVRA"


### PR DESCRIPTION
Fixing: https://redhat.atlassian.net/browse/OSCI-7778

Found out in this run of llvm-toolset module, in RHEL 8.10. Running transaction
  Preparing        :                                                        1/1 
  Erasing          : llvm-devel-18.1.8-2.module+el8.10.0+22218+ed012fd4.x   1/4 
  Running scriptlet: llvm-devel-18.1.8-2.module+el8.10.0+22218+ed012fd4.x   1/4 
/var/tmp/rpm-tmp.jDG992: line 13: syntax error near unexpected token `fi'
/var/tmp/rpm-tmp.jDG992: line 13: `fi'
warning: %postun(llvm-devel-18.1.8-2.module+el8.10.0+22218+ed012fd4.x86_64) scriptlet failed, exit status 2

Error in POSTUN scriptlet in rpm package llvm-devel
  Erasing          : llvm-test-18.1.8-2.module+el8.10.0+22218+ed012fd4.x8   2/4

Despite this error the test was reported as passed. This was reported as a failure in TPS.