### PR TITLE
Do not return 1 when test is not CRITICAL

### DIFF
--- a/mtps-run-tests
+++ b/mtps-run-tests
@@ -212,9 +212,9 @@ for nevra in $nevras_in_repo; do
     elif [ "$test_status" -eq $EXIT_CODE_WARN ]; then
         new_logfname="$(dirname "$logfname")/WARN-$(basename "$logfname")"
     elif [ "$test_status" -ne 0 ]; then
-        ret=1
         if [ -n "$CRITICAL" ]; then
             new_logfname="$(dirname "$logfname")/FAIL-$(basename "$logfname")"
+            ret=1
         else
             new_logfname="$(dirname "$logfname")/WARN-$(basename "$logfname")"
         fi


### PR DESCRIPTION
Currently this would require manual parsing of the presence of files to figure out if a non-critical test failed, which is not ideal